### PR TITLE
Allowing access to "pages" in UploadResponse

### DIFF
--- a/cloudinary-core/src/main/scala/com/cloudinary/Responses.scala
+++ b/cloudinary-core/src/main/scala/com/cloudinary/Responses.scala
@@ -35,6 +35,7 @@ case class UploadResponse(public_id: String, url: String, secure_url: String, si
   def width:Int = (raw \ "width").extractOpt[Int].getOrElse(0)
   def height:Int = (raw \ "height").extractOpt[Int].getOrElse(0)
   def format:String = (raw \ "format").extractOpt[String].getOrElse(null)
+  def pages:Int = (raw \ "pages").extractOpt[Int].getOrElse(1)
 }
 case class LargeRawUploadResponse(public_id: String, url: String, secure_url: String, signature: String, bytes: Long,
   resource_type: String, tags: List[String] = List(), upload_id:Option[String], done:Option[Boolean]) extends VersionedResponse with TimestampedResponse


### PR DESCRIPTION
Hey, maybe I'm just blind but I couldn't find a way to get the "pages" propery of an upload response, so I wondered if augmenting the UploadResponse is the solution.

If so, it might be useful to others, if I haven't seen the right option, I'd be happy to hear about it :)

Thanks and keep rockin'!
